### PR TITLE
Fix typo to clear conversation

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -218,7 +218,7 @@ async function handleMessage(message) {
 			})
 			.trim()}`;
 
-		if (userInput == ".reset") {
+		if (userInput == ".reset" || userInput == ".clear") {
 			if (!messages[channelID]) return;
 
 			// reset conversation


### PR DESCRIPTION
The message shows use `.clear` but the code only responds to `.reset`.
The updated commit allows for both `.clear` and `.reset` to be used in order to forget the history of the chat.