### PR TITLE
Process .txt files, concatenate with message.content.

### DIFF
--- a/src/bot.js
+++ b/src/bot.js
@@ -254,6 +254,20 @@ client.on(Events.MessageCreate, async message => {
 		let userInput = message.content
 			.replace(new RegExp("^\s*" + myMention.source, ""), "").trim();
 
+		// Process text file if attached
+        if (message.attachments.size > 0) {
+            const txtAttachment = message.attachments.find(att => att.name.endsWith('.txt'));
+            if (txtAttachment) {
+                try {
+                    const response = await axios.get(txtAttachment.url);
+					userInput = `${message.content}\n\n${response.data}`;
+                } catch (error) {
+                    log(LogLevel.Error, `Failed to download text file: ${error}`);
+                    return; // Stop processing if file download fails
+                }
+            }
+        }
+
 		// may change this to slash commands in the future
 		// i'm using regular text commands currently because the bot interacts with text content anyway
 		if (userInput.startsWith(".")) {

--- a/src/bot.js
+++ b/src/bot.js
@@ -254,19 +254,22 @@ client.on(Events.MessageCreate, async message => {
 		let userInput = message.content
 			.replace(new RegExp("^\s*" + myMention.source, ""), "").trim();
 
-		// Process text file if attached
-        if (message.attachments.size > 0) {
-            const txtAttachment = message.attachments.find(att => att.name.endsWith('.txt'));
-            if (txtAttachment) {
-                try {
-                    const response = await axios.get(txtAttachment.url);
-					userInput = `${message.content}\n\n${response.data}`;
-                } catch (error) {
-                    log(LogLevel.Error, `Failed to download text file: ${error}`);
-                    return; // Stop processing if file download fails
-                }
-            }
-        }
+		// Process text files if attached
+		if (message.attachments.size > 0) {
+			const textAttachments = Array.from(message.attachments, ([, value]) => value).filter(att => att.contentType.startsWith("text"));
+			if (textAttachments.length > 0) {
+				userInput = `${message.content}`;
+				try {
+					await Promise.all(textAttachments.map(async (att, i) => {
+						const response = await axios.get(att.url);
+						userInput += `\n${i + 1}. File - ${att.name}:\n${response.data}`;
+					}));
+				} catch (error) {
+					log(LogLevel.Error, `Failed to download text files: ${error}`);
+					return; // Stop processing if file download fails
+				}
+			}
+		}
 
 		// may change this to slash commands in the future
 		// i'm using regular text commands currently because the bot interacts with text content anyway


### PR DESCRIPTION
Discord tends to convert long text (about 550 words and above), such as code, in .txt files.

This change adds the feature for the bot to fetch a .txt file if attached to the message, concatenate the content to the message.content, and send it as userInput to the LLM.